### PR TITLE
Corrected misspelled comment

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -27,7 +27,7 @@ public class Robot extends TimedRobot
     CommandScheduler.getInstance().run();
   }
 
-  //Intialize Disabled Mode
+  //Initialize Disabled Mode
   @Override
   public void disabledInit() {CommandScheduler.getInstance().cancelAll();}
 


### PR DESCRIPTION
Word was missing an "i" in a particularly important comment.